### PR TITLE
Fix currency formatting based on selected country

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -504,9 +504,13 @@ function updateAmortizationChart(mortgage) {
 }
 
 function formatCurrency(amount) {
-  return new Intl.NumberFormat('en-US', {
+  const desktopCAD = document.getElementById('countryCAD');
+  const mobileCAD = document.getElementById('countryCADMobile');
+  const isCAD = (desktopCAD && desktopCAD.checked) || (mobileCAD && mobileCAD.checked);
+
+  return new Intl.NumberFormat(isCAD ? 'en-CA' : 'en-US', {
     style: 'currency',
-    currency: 'USD',
+    currency: isCAD ? 'CAD' : 'USD',
     minimumFractionDigits: 0,
     maximumFractionDigits: 0
   }).format(amount);


### PR DESCRIPTION
## Summary
- Determine chosen country when formatting currency
- Display mortgage calculator amounts in CAD or USD accordingly

## Testing
- `node --check assets/app.js`

------
https://chatgpt.com/codex/tasks/task_e_689f3347e2a0832bbdc98ee17dedb4a3