### PR TITLE
Ensure horizontal form layout above small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
     /* Better alignment for form fields */
     .form-field-wrapper {
       display: flex;
+      flex-direction: row;
       align-items: center;
       gap: 0.75rem;
       flex-wrap: nowrap;
@@ -106,7 +107,7 @@
       min-width: 0;
     }
     
-    @media (max-width: 768px) {
+    @media (max-width: 576px) {
       .form-field-wrapper {
         flex-direction: column;
         align-items: flex-start;


### PR DESCRIPTION
## Summary
- Keep form-field-wrapper horizontally aligned by default
- Lower small-screen breakpoint to 576px so laptop-width viewports stay in one line

## Testing
- ⚠️ `npm test` *(missing package.json; no tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_689f3a323ce4832b88830c7f410aaaa9