### PR TITLE
feat: update USA insurance visibility

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -177,7 +177,9 @@ function updateDownPaymentPercent() {
 }
 
 function updateUSAInsuranceVisibility() {
-  const countryUSDEl = document.getElementById('countryUSD');
+  const countryUSDEl =
+    document.getElementById('countryUSD') ||
+    document.getElementById('countryUSDMain');
   const countryUSDMobileEl = document.getElementById('countryUSDMobile');
   const homePriceEl = document.getElementById('homePrice');
   const downPaymentEl = document.getElementById('downPayment');
@@ -185,7 +187,9 @@ function updateUSAInsuranceVisibility() {
 
   if (!homePriceEl || !downPaymentEl || !usaMIChoice) return;
 
-  const isUSA = (countryUSDEl && countryUSDEl.checked) || (countryUSDMobileEl && countryUSDMobileEl.checked);
+  const isUSA =
+    (countryUSDEl && countryUSDEl.checked) ||
+    (countryUSDMobileEl && countryUSDMobileEl.checked);
   const homePrice = parseFloat(homePriceEl.value) || 0;
   const downPayment = parseFloat(downPaymentEl.value) || 0;
   const downPaymentPercent = homePrice > 0 ? (downPayment / homePrice) * 100 : 100;


### PR DESCRIPTION
## Summary
- support new `countryUSDMain` selector when toggling US mortgage insurance visibility

## Testing
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689f4a30a0e4832b80953265df96aaa1