### PR TITLE
Fix currency symbol switch for main country selector

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -85,8 +85,12 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function setupEventListeners() {
-  // Country toggle - both desktop and mobile
-  document.querySelectorAll('input[name="country"], input[name="country-mobile"]').forEach(radio => {
+  // Country toggle - desktop, main section, and mobile
+  document
+    .querySelectorAll(
+      'input[name="country"], input[name="country-main"], input[name="country-mobile"]'
+    )
+    .forEach(radio => {
     if (radio) {
       radio.addEventListener('change', function() {
         updateCurrencySymbols();

--- a/index.html
+++ b/index.html
@@ -582,27 +582,6 @@
       }
     }
     
-    // Initialize country toggle functionality
-    document.addEventListener('DOMContentLoaded', function() {
-      const countryCAD = document.getElementById('countryCADMain');
-      const countryUSD = document.getElementById('countryUSDMain');
-      
-      if (countryCAD && countryUSD) {
-        countryCAD.addEventListener('change', function() {
-          if (this.checked) {
-            // Trigger change event to update the app
-            this.dispatchEvent(new Event('change'));
-          }
-        });
-        
-        countryUSD.addEventListener('change', function() {
-          if (this.checked) {
-            // Trigger change event to update the app
-            this.dispatchEvent(new Event('change'));
-          }
-        });
-      }
-    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure country toggle on main page updates currency symbols
- remove redundant script that retriggered change events

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Financial-Calculator/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689f4f96ff64832bbab205470720b851