### PR TITLE
Add region toggle and premium ranges to term insurance calculator

### DIFF
--- a/assets/term-insurance-calculator.js
+++ b/assets/term-insurance-calculator.js
@@ -1,58 +1,40 @@
+// Term Insurance Premium Calculator Logic with US/Canada toggle
 
-// Term Insurance Premium Calculator Logic
-
-// Base premium rates per $1000 of coverage per year by age and gender (2024 market rates)
-const BASE_RATES = {
-  male: {
-    18: 0.45, 20: 0.48, 25: 0.52, 30: 0.68, 35: 0.88, 40: 1.25, 45: 1.85, 
-    50: 2.95, 55: 4.85, 60: 7.95, 65: 13.25, 70: 22.50, 75: 38.95
+const REGION_DATA = {
+  usa: {
+    locale: 'en-US',
+    currency: 'USD',
+    baseRates: {
+      male: { 18: 0.45, 20: 0.48, 25: 0.52, 30: 0.68, 35: 0.88, 40: 1.25, 45: 1.85, 50: 2.95, 55: 4.85, 60: 7.95, 65: 13.25, 70: 22.50, 75: 38.95 },
+      female: { 18: 0.38, 20: 0.41, 25: 0.44, 30: 0.56, 35: 0.72, 40: 1.02, 45: 1.48, 50: 2.28, 55: 3.68, 60: 5.95, 65: 9.85, 70: 16.75, 75: 28.95 }
+    },
+    healthMultipliers: { excellent: 1.0, good: 1.25, average: 1.65, poor: 2.85 },
+    smokingMultipliers: { never: 1.0, former: 1.45, recent: 2.15, current: 3.25 },
+    occupationMultipliers: { low: 1.0, medium: 1.25, high: 1.75, extreme: 2.45 }
   },
-  female: {
-    18: 0.38, 20: 0.41, 25: 0.44, 30: 0.56, 35: 0.72, 40: 1.02, 45: 1.48, 
-    50: 2.28, 55: 3.68, 60: 5.95, 65: 9.85, 70: 16.75, 75: 28.95
+  canada: {
+    locale: 'en-CA',
+    currency: 'CAD',
+    baseRates: {
+      male: { 18: 0.38, 20: 0.41, 25: 0.44, 30: 0.58, 35: 0.75, 40: 1.06, 45: 1.57, 50: 2.51, 55: 4.12, 60: 6.76, 65: 11.26, 70: 19.13, 75: 33.11 },
+      female: { 18: 0.32, 20: 0.35, 25: 0.37, 30: 0.48, 35: 0.61, 40: 0.87, 45: 1.26, 50: 1.94, 55: 3.13, 60: 5.06, 65: 8.37, 70: 14.24, 75: 24.61 }
+    },
+    healthMultipliers: { excellent: 1.0, good: 1.22, average: 1.58, poor: 2.68 },
+    smokingMultipliers: { never: 1.0, former: 1.38, recent: 2.05, current: 3.05 },
+    occupationMultipliers: { low: 1.0, medium: 1.22, high: 1.68, extreme: 2.28 }
   }
 };
 
-// Risk multipliers (2024 market standards)
-const HEALTH_MULTIPLIERS = {
-  excellent: 1.0,
-  good: 1.25,
-  average: 1.65,
-  poor: 2.85
-};
-
-const SMOKING_MULTIPLIERS = {
-  never: 1.0,
-  former: 1.45,
-  recent: 2.15,
-  current: 3.25
-};
-
-const OCCUPATION_MULTIPLIERS = {
-  low: 1.0,
-  medium: 1.25,
-  high: 1.75,
-  extreme: 2.45
-};
-
-const COUNTRY_MULTIPLIERS = {
-  usa: 1.0,
-  canada: 0.85
-};
-
-// Term length multipliers (longer terms cost more due to level premiums)
-const TERM_MULTIPLIERS = {
-  10: 0.85,
-  15: 0.92,
-  20: 1.0,
-  25: 1.08,
-  30: 1.15
-};
+const TERM_MULTIPLIERS = { 10: 0.85, 15: 0.92, 20: 1.0, 25: 1.08, 30: 1.15 };
+const VARIATION_PERCENT = 0.15; // range +/-15%
 
 class TermInsuranceCalculator {
   constructor() {
+    this.region = 'usa';
     this.initializeEventListeners();
     this.handleCustomCoverage();
+    this.setupRegionToggle();
+    this.updateCurrencyLabels();
   }
 
   initializeEventListeners() {
@@ -60,25 +42,54 @@ class TermInsuranceCalculator {
     const coverageSelect = document.getElementById('coverage');
     const ageSlider = document.getElementById('age');
     const ageDisplay = document.getElementById('ageValue');
-    
+
     calculateBtn.addEventListener('click', () => this.calculatePremium());
     coverageSelect.addEventListener('change', () => this.handleCustomCoverage());
-    
-    // Update age display when slider changes
+
     if (ageSlider && ageDisplay) {
       ageSlider.addEventListener('input', () => {
         ageDisplay.textContent = ageSlider.value;
-        // Remove auto-calculation - user must click Calculate button
       });
     }
-    
-    // Remove real-time calculation - user must click Calculate button
+  }
+
+  setupRegionToggle() {
+    const toggle = document.getElementById('regionToggle');
+    if (toggle) {
+      toggle.querySelectorAll('button').forEach(btn => {
+        btn.addEventListener('click', () => {
+          toggle.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          this.region = btn.dataset.region;
+          this.updateCurrencyLabels();
+        });
+      });
+    }
+  }
+
+  updateCurrencyLabels() {
+    const prefix = this.region === 'canada' ? 'CA$' : '$';
+    const coverageSelect = document.getElementById('coverage');
+    if (coverageSelect) {
+      [...coverageSelect.options].forEach(opt => {
+        if (opt.value !== 'custom') {
+          const val = parseInt(opt.value, 10).toLocaleString();
+          opt.textContent = `${prefix}${val}`;
+        } else {
+          opt.textContent = 'Custom Amount';
+        }
+      });
+    }
+    const customLabel = document.querySelector('label[for="customCoverage"]');
+    if (customLabel) {
+      customLabel.textContent = `Custom Coverage Amount (${prefix})`;
+    }
   }
 
   handleCustomCoverage() {
     const coverageSelect = document.getElementById('coverage');
     const customGroup = document.getElementById('customCoverageGroup');
-    
+
     if (coverageSelect.value === 'custom') {
       customGroup.style.display = 'block';
     } else {
@@ -90,13 +101,13 @@ class TermInsuranceCalculator {
     const ageInput = document.getElementById('age');
     const ageValue = ageInput ? ageInput.value.toString().trim() : '';
     const age = ageValue ? parseInt(ageValue, 10) : NaN;
-    
+
     const genderInput = document.getElementById('gender');
     const gender = genderInput ? genderInput.value : 'male';
-    
+
     const coverageSelect = document.getElementById('coverage');
     const coverageValue = coverageSelect ? coverageSelect.value : '250000';
-    
+
     let coverage;
     if (coverageValue === 'custom') {
       const customInput = document.getElementById('customCoverage');
@@ -105,33 +116,29 @@ class TermInsuranceCalculator {
     } else {
       coverage = parseInt(coverageValue, 10);
     }
-    
+
     const termInput = document.getElementById('term');
     const termValue = termInput ? termInput.value.toString().trim() : '';
     const term = termValue ? parseInt(termValue, 10) : NaN;
-    
+
     const healthInput = document.getElementById('health');
     const health = healthInput ? healthInput.value : 'excellent';
-    
+
     const smokingInput = document.getElementById('smoking');
     const smoking = smokingInput ? smokingInput.value : 'never';
-    
+
     const occupationInput = document.getElementById('occupation');
     const occupation = occupationInput ? occupationInput.value : 'low';
-    
-    const countryInput = document.getElementById('country');
-    const country = countryInput ? countryInput.value : 'usa';
 
-    console.log('Debug - Age input:', ageValue, 'Parsed age:', age, 'Is valid:', !isNaN(age) && age >= 18 && age <= 75);
-    
+    const country = this.region;
+
     return { age, gender, coverage, term, health, smoking, occupation, country };
   }
 
-  getBaseRateForAge(age, gender) {
-    const rates = BASE_RATES[gender] || BASE_RATES.male;
+  getBaseRateForAge(age, gender, baseRates) {
+    const rates = baseRates[gender] || baseRates.male;
     const ageKeys = Object.keys(rates).map(Number).sort((a, b) => a - b);
-    
-    // Find the closest age bracket
+
     let closestAge = ageKeys[0];
     for (let ageKey of ageKeys) {
       if (age >= ageKey) {
@@ -140,37 +147,31 @@ class TermInsuranceCalculator {
         break;
       }
     }
-    
-    return rates[closestAge] || rates[75]; // Default to highest rate if over 75
+
+    return rates[closestAge] || rates[ageKeys[ageKeys.length - 1]];
   }
 
   calculatePremium() {
-    // Clear any previous error display
     const resultsSection = document.getElementById('resultsSection');
     if (resultsSection) {
       resultsSection.style.display = 'none';
     }
-    
+
     const { age, gender, coverage, term, health, smoking, occupation, country } = this.getInputValues();
-    
-    console.log('Debug - Validation inputs:', { age, gender, coverage, term });
-    
-    // Validate inputs with more detailed error messages
+
     if (isNaN(age)) {
       this.showError('Please enter a valid age');
       return;
     }
-    
     if (age < 18 || age > 70) {
       this.showError(`Age must be between 18 and 70 years for insurance coverage (you entered: ${age})`);
       return;
     }
-    
+
     if (isNaN(coverage)) {
       this.showError('Please enter a valid coverage amount');
       return;
     }
-    
     if (coverage < 50000 || coverage > 10000000) {
       this.showError('Coverage amount must be between $50,000 and $10,000,000');
       return;
@@ -180,87 +181,83 @@ class TermInsuranceCalculator {
       this.showError('Please select a valid policy term');
       return;
     }
-    
     if (term < 10 || term > 30) {
       this.showError('Policy term must be between 10 and 30 years');
       return;
     }
 
-    // Calculate base premium
-    const baseRate = this.getBaseRateForAge(age, gender);
+    const region = REGION_DATA[country];
+    const baseRate = this.getBaseRateForAge(age, gender, region.baseRates);
     const basePremiumAnnual = (coverage / 1000) * baseRate;
-    
-    // Apply multipliers
-    const healthMultiplier = HEALTH_MULTIPLIERS[health] || 1.0;
-    const smokingMultiplier = SMOKING_MULTIPLIERS[smoking] || 1.0;
-    const occupationMultiplier = OCCUPATION_MULTIPLIERS[occupation] || 1.0;
-    const countryMultiplier = COUNTRY_MULTIPLIERS[country] || 1.0;
+
+    const healthMultiplier = region.healthMultipliers[health] || 1.0;
+    const smokingMultiplier = region.smokingMultipliers[smoking] || 1.0;
+    const occupationMultiplier = region.occupationMultipliers[occupation] || 1.0;
     const termMultiplier = TERM_MULTIPLIERS[term] || 1.0;
-    
-    // Calculate final premium
-    const totalMultiplier = healthMultiplier * smokingMultiplier * occupationMultiplier * countryMultiplier * termMultiplier;
+
+    const totalMultiplier = healthMultiplier * smokingMultiplier * occupationMultiplier * termMultiplier;
     const finalAnnualPremium = basePremiumAnnual * totalMultiplier;
     const finalMonthlyPremium = finalAnnualPremium / 12;
-    
-    // Calculate breakdown amounts
+
+    const annualLow = finalAnnualPremium * (1 - VARIATION_PERCENT);
+    const annualHigh = finalAnnualPremium * (1 + VARIATION_PERCENT);
+    const monthlyLow = annualLow / 12;
+    const monthlyHigh = annualHigh / 12;
+    const totalLow = annualLow * term;
+    const totalHigh = annualHigh * term;
+
     const healthAdjustment = basePremiumAnnual * (healthMultiplier - 1) / 12;
     const smokingAdjustment = basePremiumAnnual * healthMultiplier * (smokingMultiplier - 1) / 12;
     const occupationAdjustment = basePremiumAnnual * healthMultiplier * smokingMultiplier * (occupationMultiplier - 1) / 12;
-    const regionalAdjustment = basePremiumAnnual * healthMultiplier * smokingMultiplier * occupationMultiplier * (countryMultiplier - 1) / 12;
-    
-    // Display results
+
     this.displayResults({
-      monthlyPremium: finalMonthlyPremium,
-      annualPremium: finalAnnualPremium,
-      totalPremium: finalAnnualPremium * term,
+      region: country,
+      monthlyLow,
+      monthlyHigh,
+      annualLow,
+      annualHigh,
+      totalLow,
+      totalHigh,
       coverageRatio: coverage / finalMonthlyPremium,
       basePremium: basePremiumAnnual / 12,
       healthAdjustment,
       smokingAdjustment,
       occupationAdjustment,
-      regionalAdjustment,
-      finalPremium: finalMonthlyPremium
+      finalLow: monthlyLow,
+      finalHigh: monthlyHigh
     });
   }
 
   displayResults(results) {
+    const region = REGION_DATA[results.region];
     const resultsSection = document.getElementById('resultsSection');
     resultsSection.style.display = 'block';
-    
-    // Format currency
-    const fmt = (amount) => new Intl.NumberFormat('en-US', {
+
+    const fmt = amount => new Intl.NumberFormat(region.locale, {
       style: 'currency',
-      currency: 'USD',
+      currency: region.currency,
       minimumFractionDigits: 0,
       maximumFractionDigits: 0
     }).format(Math.round(amount));
 
-    const fmtDecimal = (amount) => new Intl.NumberFormat('en-US', {
+    const fmtDecimal = amount => new Intl.NumberFormat(region.locale, {
       style: 'currency',
-      currency: 'USD',
+      currency: region.currency,
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
     }).format(amount);
 
-    // Update main results
-    document.getElementById('monthlyPremium').textContent = fmtDecimal(results.monthlyPremium);
-    document.getElementById('annualPremium').textContent = fmt(results.annualPremium);
-    document.getElementById('totalPremium').textContent = fmt(results.totalPremium);
+    document.getElementById('monthlyPremium').textContent = `${fmtDecimal(results.monthlyLow)} - ${fmtDecimal(results.monthlyHigh)}`;
+    document.getElementById('annualPremium').textContent = `${fmt(results.annualLow)} - ${fmt(results.annualHigh)}`;
+    document.getElementById('totalPremium').textContent = `${fmt(results.totalLow)} - ${fmt(results.totalHigh)}`;
     document.getElementById('coverageRatio').textContent = fmt(results.coverageRatio);
 
-    // Update breakdown
     document.getElementById('basePremium').textContent = fmtDecimal(results.basePremium);
-    document.getElementById('healthAdjustment').textContent = results.healthAdjustment >= 0 ? 
-      `+${fmtDecimal(results.healthAdjustment)}` : fmtDecimal(results.healthAdjustment);
-    document.getElementById('smokingAdjustment').textContent = results.smokingAdjustment >= 0 ? 
-      `+${fmtDecimal(results.smokingAdjustment)}` : fmtDecimal(results.smokingAdjustment);
-    document.getElementById('occupationAdjustment').textContent = results.occupationAdjustment >= 0 ? 
-      `+${fmtDecimal(results.occupationAdjustment)}` : fmtDecimal(results.occupationAdjustment);
-    document.getElementById('regionalAdjustment').textContent = results.regionalAdjustment >= 0 ? 
-      `+${fmtDecimal(results.regionalAdjustment)}` : fmtDecimal(results.regionalAdjustment);
-    document.getElementById('finalPremium').textContent = fmtDecimal(results.finalPremium);
+    document.getElementById('healthAdjustment').textContent = results.healthAdjustment >= 0 ? `+${fmtDecimal(results.healthAdjustment)}` : fmtDecimal(results.healthAdjustment);
+    document.getElementById('smokingAdjustment').textContent = results.smokingAdjustment >= 0 ? `+${fmtDecimal(results.smokingAdjustment)}` : fmtDecimal(results.smokingAdjustment);
+    document.getElementById('occupationAdjustment').textContent = results.occupationAdjustment >= 0 ? `+${fmtDecimal(results.occupationAdjustment)}` : fmtDecimal(results.occupationAdjustment);
+    document.getElementById('finalPremium').textContent = `${fmtDecimal(results.finalLow)} - ${fmtDecimal(results.finalHigh)}`;
 
-    // Scroll to results
     resultsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
@@ -281,12 +278,11 @@ class TermInsuranceCalculator {
   }
 }
 
-// Initialize calculator when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
   new TermInsuranceCalculator();
 });
 
-// Export for testing purposes
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = TermInsuranceCalculator;
 }
+

--- a/facebook-calculator.html
+++ b/facebook-calculator.html
@@ -311,7 +311,6 @@
         <div class="collapse navbar-collapse" id="mainNav">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="index.html">Mortgage</a></li>
-            <li class="nav-item"><a class="nav-link" href="gst-hst.html">GST/HST</a></li>
             <li class="nav-item"><a class="nav-link" href="youtube-calculator.html">YouTube</a></li>
             <li class="nav-item"><a class="nav-link active" href="facebook-calculator.html">Facebook</a></li>
             <li class="nav-item"><a class="nav-link" href="instagram-calculator.html">Instagram</a></li>

--- a/instagram-calculator.html
+++ b/instagram-calculator.html
@@ -309,7 +309,6 @@
         <div class="collapse navbar-collapse" id="mainNav">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="index.html">Mortgage</a></li>
-            <li class="nav-item"><a class="nav-link" href="gst-hst.html">GST/HST</a></li>
             <li class="nav-item"><a class="nav-link" href="youtube-calculator.html">YouTube</a></li>
             <li class="nav-item"><a class="nav-link" href="facebook-calculator.html">Facebook</a></li>
             <li class="nav-item"><a class="nav-link active" href="instagram-calculator.html">Instagram</a></li>

--- a/term-insurance-calculator.html
+++ b/term-insurance-calculator.html
@@ -532,7 +532,6 @@
         <div class="collapse navbar-collapse" id="mainNav">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="index.html">Mortgage</a></li>
-            <li class="nav-item"><a class="nav-link" href="gst-hst.html">GST/HST</a></li>
             <li class="nav-item"><a class="nav-link" href="youtube-calculator.html">YouTube</a></li>
             <li class="nav-item"><a class="nav-link" href="facebook-calculator.html">Facebook</a></li>
             <li class="nav-item"><a class="nav-link" href="instagram-calculator.html">Instagram</a></li>
@@ -630,11 +629,11 @@
         </div>
 
         <div class="input-group">
-          <label for="country">Country/Region</label>
-          <select id="country">
-            <option value="usa" selected>United States</option>
-            <option value="canada">Canada</option>
-          </select>
+          <label>Region</label>
+          <div class="btn-group" role="group" id="regionToggle">
+            <button type="button" class="btn btn-outline-primary active" data-region="usa">USA</button>
+            <button type="button" class="btn btn-outline-primary" data-region="canada">Canada</button>
+          </div>
         </div>
       </div>
 
@@ -688,10 +687,6 @@
         <div class="breakdown-item">
           <span>Occupation Risk:</span>
           <span id="occupationAdjustment">$0</span>
-        </div>
-        <div class="breakdown-item">
-          <span>Regional Factor:</span>
-          <span id="regionalAdjustment">$0</span>
         </div>
         <div class="breakdown-item total">
           <span><strong>Final Monthly Premium:</strong></span>

--- a/universal-life-calculator.html
+++ b/universal-life-calculator.html
@@ -139,7 +139,6 @@
         <div class="collapse navbar-collapse" id="mainNav">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="index.html">Mortgage</a></li>
-            <li class="nav-item"><a class="nav-link" href="gst-hst.html">GST/HST</a></li>
             <li class="nav-item"><a class="nav-link" href="youtube-calculator.html">YouTube</a></li>
             <li class="nav-item"><a class="nav-link" href="facebook-calculator.html">Facebook</a></li>
             <li class="nav-item"><a class="nav-link" href="instagram-calculator.html">Instagram</a></li>

--- a/youtube-calculator.html
+++ b/youtube-calculator.html
@@ -382,7 +382,6 @@
         <div class="collapse navbar-collapse" id="mainNav">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="index.html">Mortgage</a></li>
-            <li class="nav-item"><a class="nav-link" href="gst-hst.html">GST/HST</a></li>
             <li class="nav-item"><a class="nav-link active" href="youtube-calculator.html">YouTube</a></li>
             <li class="nav-item"><a class="nav-link" href="facebook-calculator.html">Facebook</a></li>
             <li class="nav-item"><a class="nav-link" href="instagram-calculator.html">Instagram</a></li>


### PR DESCRIPTION
## Summary
- replace country dropdown with USA/Canada toggle
- show monthly, annual, and total term premiums as ranges using regional data
- drop all GST/HST links from top navigation

## Testing
- `node --check assets/term-insurance-calculator.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5839a330832b84f96f24c8647662