### PR TITLE
fix: restore checkbox interactivity

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -117,21 +117,27 @@ h1{
   line-height:1.4;
 }
 
-input,select{
-  width:100%; 
-  padding:12px; 
-  background:#fff; 
-  border:1px solid var(--border); 
-  border-radius:10px; 
+/*
+ * Generic input styles previously applied to all <input> elements, which caused
+ * checkbox controls to lose their native appearance and become non-interactive
+ * in sections like "Health & Habits". Limit these rules to non-checkbox/radio
+ * inputs so that checkboxes retain default rendering and remain clickable.
+ */
+input:not([type="checkbox"]):not([type="radio"]), select{
+  width:100%;
+  padding:12px;
+  background:#fff;
+  border:1px solid var(--border);
+  border-radius:10px;
   color:var(--text);
   font-size:16px; /* Prevents zoom on iOS */
   -webkit-appearance:none;
 }
-@media(min-width:768px){ 
-  input,select{padding:10px 12px; font-size:14px;} 
+@media(min-width:768px){
+  input:not([type="checkbox"]):not([type="radio"]), select{padding:10px 12px; font-size:14px;}
 }
-input:focus,select:focus{
-  outline:2px solid rgba(37,99,235,.25); 
+input:not([type="checkbox"]):not([type="radio"]):focus, select:focus{
+  outline:2px solid rgba(37,99,235,.25);
   border-color:#bfdbfe;
 }
 


### PR DESCRIPTION
## Summary
- Exclude checkbox and radio inputs from global styling to restore their default appearance and enable clicking in Health & Habits section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6312de30832b9251a2d15d154ae6