### PR TITLE
Align index breakdown sections with site layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,13 +44,6 @@
       }
     }
     
-    .results-card {
-      background: #f8f9fa;
-      border: 1px solid #dee2e6;
-      border-radius: 0.375rem;
-      padding: 1.5rem;
-      margin: 1.5rem 0;
-    }
     
     .faq-toggle {
       background: none;
@@ -317,52 +310,54 @@
 
     <!-- Mortgage Breakdown (Results Summary) -->
     <section class="container mb-4">
-      <div class="results-card" aria-live="polite">
-        <h2 class="h5 mb-3">Mortgage Payment & Cost Breakdown</h2>
-        
-        <div class="row mb-3">
-          <div class="col-md-6">
-            <div class="text-muted small">Per‑period mortgage payment (P&I)</div>
-            <div class="fs-4 fw-semibold" id="paymentDisplay">$0.00</div>
-            <div class="small text-muted" id="frequencyLabel">Monthly • 12 payments/yr</div>
-          </div>
-          <div class="col-md-6">
-            <div class="text-muted small">Monthly equivalent (P&I)</div>
-            <div class="fs-4 fw-semibold" id="monthlyEquiv">$0.00</div>
-            <div class="small text-muted">
-              <span>LTV: </span><span id="ltvDisplay">0%</span> |
-              <span id="miSummary">—</span>
+      <div class="card border-0 shadow-sm">
+        <div class="card-body" aria-live="polite">
+          <h2 class="h5 mb-3">Mortgage Payment & Cost Breakdown</h2>
+
+          <div class="row mb-3">
+            <div class="col-md-6">
+              <div class="text-muted small">Per‑period mortgage payment (P&I)</div>
+              <div class="fs-4 fw-semibold" id="paymentDisplay">$0.00</div>
+              <div class="small text-muted" id="frequencyLabel">Monthly • 12 payments/yr</div>
+            </div>
+            <div class="col-md-6">
+              <div class="text-muted small">Monthly equivalent (P&I)</div>
+              <div class="fs-4 fw-semibold" id="monthlyEquiv">$0.00</div>
+              <div class="small text-muted">
+                <span>LTV: </span><span id="ltvDisplay">0%</span> |
+                <span id="miSummary">—</span>
+              </div>
             </div>
           </div>
-        </div>
 
-        <h3 class="h6 mt-4 mb-3">Total Monthly Cost of Ownership</h3>
-        <ul class="list-group" id="ownershipList">
-          <li class="list-group-item d-flex justify-content-between">
-            <span>Mortgage P&I (monthly equivalent)</span>
-            <span id="ownershipPI">$0</span>
-          </li>
-          <li class="list-group-item d-flex justify-content-between">
-            <span>Mortgage insurance</span>
-            <span id="ownershipMI">$0</span>
-          </li>
-          <li class="list-group-item d-flex justify-content-between">
-            <span>Property tax</span>
-            <span id="ownershipTax">$0</span>
-          </li>
-          <li class="list-group-item d-flex justify-content-between">
-            <span>Condo fee</span>
-            <span id="ownershipCondo">$0</span>
-          </li>
-          <li class="list-group-item d-flex justify-content-between">
-            <span>Utilities (Water + Electric + Heat)</span>
-            <span id="ownershipUtilities">$0</span>
-          </li>
-          <li class="list-group-item d-flex justify-content-between fw-bold bg-light">
-            <span>Total Monthly Cost</span>
-            <span id="ownershipTotal">$0</span>
-          </li>
-        </ul>
+          <h3 class="h6 mt-4 mb-3">Total Monthly Cost of Ownership</h3>
+          <ul class="list-group" id="ownershipList">
+            <li class="list-group-item d-flex justify-content-between">
+              <span>Mortgage P&I (monthly equivalent)</span>
+              <span id="ownershipPI">$0</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+              <span>Mortgage insurance</span>
+              <span id="ownershipMI">$0</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+              <span>Property tax</span>
+              <span id="ownershipTax">$0</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+              <span>Condo fee</span>
+              <span id="ownershipCondo">$0</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+              <span>Utilities (Water + Electric + Heat)</span>
+              <span id="ownershipUtilities">$0</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between fw-bold bg-light">
+              <span>Total Monthly Cost</span>
+              <span id="ownershipTotal">$0</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Replace custom results-card with Bootstrap card wrapper in "Mortgage Payment & Cost Breakdown"
- Ensure "Amortization by Year" section follows same container/card layout
- Remove unused results-card styles from index page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f63b895b4832b91b7b29095d88c0b