### PR TITLE
Add geotagging for country toggles

### DIFF
--- a/assets/geotag.js
+++ b/assets/geotag.js
@@ -1,0 +1,43 @@
+// Geotagging script to set default country toggles based on user location
+// Uses IP-based geolocation to determine country.
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('https://ipapi.co/json/')
+    .then(res => res.json())
+    .then(data => {
+      const code = (data && data.country || '').toUpperCase();
+      const useCanada = code === 'CA';
+      // Mortgage calculator (index.html)
+      const cad = document.getElementById('countryCADMain');
+      const usd = document.getElementById('countryUSDMain');
+      if (cad && usd) {
+        const target = useCanada ? cad : usd;
+        target.checked = true;
+        target.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      // Universal life calculator
+      const countryToggle = document.getElementById('countryToggle');
+      if (countryToggle) {
+        const btn = useCanada
+          ? countryToggle.querySelector('[data-country="canada"]')
+          : countryToggle.querySelector('[data-country="usa"]');
+        if (btn) btn.click();
+      }
+      // Term insurance calculator
+      const regionToggle = document.getElementById('regionToggle');
+      if (regionToggle) {
+        const btn = useCanada
+          ? regionToggle.querySelector('[data-region="canada"]')
+          : regionToggle.querySelector('[data-region="usa"]');
+        if (btn) btn.click();
+      }
+    })
+    .catch(() => {
+      // On failure, default to USA on mortgage calculator
+      const cad = document.getElementById('countryCADMain');
+      const usd = document.getElementById('countryUSDMain');
+      if (cad && usd) {
+        usd.checked = true;
+        usd.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    });
+});

--- a/index.html
+++ b/index.html
@@ -560,6 +560,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="assets/app.js"></script>
+  <script src="assets/geotag.js"></script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
     

--- a/term-insurance-calculator.html
+++ b/term-insurance-calculator.html
@@ -763,5 +763,6 @@
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="assets/term-insurance-calculator.js"></script>
+  <script src="assets/geotag.js"></script>
 </body>
 </html>

--- a/universal-life-calculator.html
+++ b/universal-life-calculator.html
@@ -518,5 +518,6 @@
 
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="assets/universal-life-calculator.js"></script>
+  <script src="assets/geotag.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Detect user location and toggle country to Canada or USA
- Include shared geotag script across mortgage, term insurance, and universal life calculators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6632d618832b84fc92033bc7a8b3