### PR TITLE
Adjust monetizable views to exclude Premium users

### DIFF
--- a/assets/youtube-calculator.js
+++ b/assets/youtube-calculator.js
@@ -43,7 +43,7 @@ const calc = () => {
   // Long-form ads revenue
   if ((fmt === 'long' || fmt === 'both') && inputs.modWatch()) {
     const views = inputs.viewsLF();
-    const monetizableViews = views * (inputs.monetizableRate() / 100);
+    const monetizableViews = views * (inputs.monetizableRate() / 100) * (1 - inputs.premiumViews() / 100);
     
     // Calculate ad impressions per view
     let adImpressions = 0;


### PR DESCRIPTION
## Summary
- Exclude Premium viewers when computing monetizable views so ad revenue reflects only non-Premium audiences
- Confirm Premium view percentage input is constrained to 0-100%

## Testing
- `node --check assets/youtube-calculator.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f69ef40d0832b87757ac13c2a9013