### PR TITLE
feat: add slot-specific fill rates and retention

### DIFF
--- a/youtube-calculator.html
+++ b/youtube-calculator.html
@@ -527,6 +527,11 @@
             <label for="midrolls">Mid-rolls count <span class="info" title="Number of mid-roll ad breaks (enabled for videos 8+ minutes)">ⓘ</span></label>
             <input type="number" id="midrolls" min="0" step="1" value="2">
           </div>
+
+          <div class="input-group">
+            <label for="avgViewDuration">Average view duration (minutes) <span class="info" title="Average minutes watched per view">ⓘ</span></label>
+            <input type="number" id="avgViewDuration" min="0" step="0.1" value="5">
+          </div>
         </div>
 
         <h3>2) Viewer & Context</h3>
@@ -550,10 +555,28 @@
         </div>
 
         <div class="input-group">
-          <label for="adFillRate">Ad fill rate % <span class="info" title="Percentage of ad slots that get filled">ⓘ</span></label>
+          <label for="preFill">Pre-roll fill rate % <span class="info" title="Percentage of pre-roll ad slots filled">ⓘ</span></label>
           <div class="slider-group">
-            <input type="range" id="adFillRate" min="0" max="100" value="90">
-            <input type="number" id="adFillRateNum" min="0" max="100" value="90" class="slider-num">
+            <input type="range" id="preFill" min="0" max="100" value="95">
+            <input type="number" id="preFillNum" min="0" max="100" value="95" class="slider-num">
+            <span>%</span>
+          </div>
+        </div>
+
+        <div class="input-group">
+          <label for="midFill">Mid-roll fill rate % <span class="info" title="Percentage of mid-roll ad slots filled">ⓘ</span></label>
+          <div class="slider-group">
+            <input type="range" id="midFill" min="0" max="100" value="90">
+            <input type="number" id="midFillNum" min="0" max="100" value="90" class="slider-num">
+            <span>%</span>
+          </div>
+        </div>
+
+        <div class="input-group">
+          <label for="postFill">Post-roll fill rate % <span class="info" title="Percentage of post-roll ad slots filled">ⓘ</span></label>
+          <div class="slider-group">
+            <input type="range" id="postFill" min="0" max="100" value="80">
+            <input type="number" id="postFillNum" min="0" max="100" value="80" class="slider-num">
             <span>%</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add separate pre-, mid-, and post-roll fill rate inputs
- account for viewer retention via average view duration when estimating ad impressions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d163cd4832bae3a8a9246f6c126