### PR TITLE
Adjust premium revenue share calculation

### DIFF
--- a/assets/youtube-calculator.js
+++ b/assets/youtube-calculator.js
@@ -29,6 +29,7 @@ const inputs = {
   inventoryAvail: () => clamp(Number($('#inventoryAvail').value||100), 50, 100),
   creatorShareLF: () => clamp(Number($('#creatorShareLF').value||55), 0, 100),
   creatorShareShorts: () => clamp(Number($('#creatorShareShorts').value||45), 0, 100),
+  creatorSharePremium: () => clamp(Number($('#creatorSharePremium').value||55), 0, 100),
   additionalSharing: () => clamp(Number($('#additionalSharing').value||0), 0, 50),
   manualImp: () => $('#manualImp').checked,
   adImpressionsManual: () => Math.max(0, Number($('#adImpressionsManual').value||2.5)),
@@ -73,11 +74,13 @@ const calc = () => {
 
   // Premium revenue
   if (inputs.modPremium()) {
-    const totalViews = (fmt === 'long' ? inputs.viewsLF() : 0) + 
+    const totalViews = (fmt === 'long' ? inputs.viewsLF() : 0) +
                       (fmt === 'shorts' ? inputs.viewsShorts() : 0) +
                       (fmt === 'both' ? inputs.viewsLF() + inputs.viewsShorts() : 0);
     const premiumViews = totalViews * (inputs.premiumViews() / 100);
     premiumUSD = (premiumViews / 1000) * inputs.premiumRPM();
+    const premiumShare = premiumUSD * (inputs.creatorSharePremium() / 100);
+    premiumUSD = premiumShare * (1 - inputs.additionalSharing() / 100);
   }
 
   const total = lfAdsUSD + shortsUSD + premiumUSD;
@@ -220,6 +223,7 @@ const resetToDefaults = ()=>{
   // Rights & Revenue
   $('#creatorShareLF').value = 55;
   $('#creatorShareShorts').value = 45;
+  $('#creatorSharePremium').value = 55;
   $('#additionalSharing').value = 0;
   $('#additionalSharingNum').value = 0;
   

--- a/youtube-calculator.html
+++ b/youtube-calculator.html
@@ -608,6 +608,11 @@
         </div>
 
         <div class="input-group">
+          <label for="creatorSharePremium">Creator revenue share % (Premium) <span class="info" title="Your share of Premium revenue">ⓘ</span></label>
+          <input type="number" id="creatorSharePremium" min="0" max="100" value="55">
+        </div>
+
+        <div class="input-group">
           <label for="additionalSharing">Additional revenue sharing reductions % <span class="info" title="Music/license splits and other deductions">ⓘ</span></label>
           <div class="slider-group">
             <input type="range" id="additionalSharing" min="0" max="50" value="0">


### PR DESCRIPTION
## Summary
- Add separate `creatorSharePremium` input and apply additional sharing deductions to premium earnings.
- Include Premium revenue share field in YouTube calculator HTML.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d0bba74832b8b661975952eab83