### PR TITLE
Add qualified play rate and creator share to Reels calculators

### DIFF
--- a/assets/facebook-calculator.js
+++ b/assets/facebook-calculator.js
@@ -34,7 +34,9 @@ const inputs = {
   // Reels
   reelsPlays: () => Math.max(0, Number($('#reelsPlays').value||0)),
   reelsRPM: () => Math.max(0, Number($('#reelsRPM').value||0)),
-  
+  qualifiedPlayRate: () => clamp(Number($('#qualifiedPlayRate').value||100), 0, 100),
+  reelsCreatorShare: () => clamp(Number($('#reelsCreatorShare').value||45), 0, 100),
+
   // Long-form
   longformViews: () => Math.max(0, Number($('#longformViews').value||0)),
   monetizableRate: () => clamp(Number($('#monetizableRate').value||85), 0, 100),
@@ -97,8 +99,9 @@ const calc = () => {
 
   const subscriptionsUSD = netApp + netWeb;
   
-  // Reels Revenue = Plays × (Effective_RPM / 1000)
-  const reelsUSD = inputs.reelsPlays() * (inputs.reelsRPM() / 1000);
+  // Reels Revenue = Qualified_Plays × (Effective_RPM / 1000) × Creator_Share
+  const qualifiedPlays = inputs.reelsPlays() * (inputs.qualifiedPlayRate() / 100);
+  const reelsUSD = qualifiedPlays * (inputs.reelsRPM() / 1000) * (inputs.reelsCreatorShare() / 100);
   
   // Long-form Revenue
   const eligibleViews = inputs.longformViews() * (inputs.monetizableRate() / 100);
@@ -224,6 +227,8 @@ const resetToDefaults = () => {
   // Reels
   $('#reelsPlays').value = 100000;
   $('#reelsRPM').value = 0.90;
+  $('#qualifiedPlayRate').value = 100;
+  $('#reelsCreatorShare').value = 45;
   
   // Long-form
   $('#longformViews').value = 50000;

--- a/assets/instagram-calculator.js
+++ b/assets/instagram-calculator.js
@@ -28,6 +28,11 @@ const inputs = {
   // Reels
   reelsPlays: () => parseFloat($('#reelsPlays').value) || 0,
   reelsRPM: () => parseFloat($('#reelsRPM').value) || 0,
+  qualifiedPlayRate: () => parseFloat($('#qualifiedPlayRate').value) || 0,
+  reelsCreatorShare: () => {
+    const val = parseFloat($('#reelsCreatorShare').value);
+    return isNaN(val) ? 45 : val;
+  },
 };
 
 // ===== Eligibility Check =====
@@ -76,7 +81,8 @@ const calculateSubscriptions = () => {
 
 // Reels_Revenue = Plays × (Effective_RPM / 1000)
 const calculateReels = () => {
-  return inputs.reelsPlays() * (inputs.reelsRPM() / 1000);
+  const qualifiedPlays = inputs.reelsPlays() * inputs.qualifiedPlayRate() / 100;
+  return qualifiedPlays * (inputs.reelsRPM() / 1000) * (inputs.reelsCreatorShare() / 100);
 };
 
 // ===== Main Calculation Function =====
@@ -143,6 +149,8 @@ const getURLState = () => {
     platformFee: params.get('platformFee') || '0',
     reelsPlays: params.get('reelsPlays') || '1000000',
     reelsRPM: params.get('reelsRPM') || '0.90',
+    qualifiedPlayRate: params.get('qualifiedPlayRate') || '100',
+    reelsCreatorShare: params.get('reelsCreatorShare') || '45',
     eligibility1: params.get('eligibility1') !== 'false',
     eligibility2: params.get('eligibility2') !== 'false',
     eligibility3: params.get('eligibility3') !== 'false',
@@ -163,6 +171,8 @@ const setURLState = () => {
   params.set('platformFee', $('#platformFee').value);
   params.set('reelsPlays', $('#reelsPlays').value);
   params.set('reelsRPM', $('#reelsRPM').value);
+  params.set('qualifiedPlayRate', $('#qualifiedPlayRate').value);
+  params.set('reelsCreatorShare', $('#reelsCreatorShare').value);
   params.set('eligibility1', $('#eligibility1').checked);
   params.set('eligibility2', $('#eligibility2').checked);
   params.set('eligibility3', $('#eligibility3').checked);
@@ -190,6 +200,8 @@ const loadFromURL = () => {
   $('#platformFee').value = state.platformFee;
   $('#reelsPlays').value = state.reelsPlays;
   $('#reelsRPM').value = state.reelsRPM;
+  $('#qualifiedPlayRate').value = state.qualifiedPlayRate;
+  $('#reelsCreatorShare').value = state.reelsCreatorShare;
   
   // Set eligibility checkboxes
   $('#eligibility1').checked = state.eligibility1;
@@ -229,6 +241,8 @@ const resetToDefaults = () => {
   $('#platformFee').value = '0';
   $('#reelsPlays').value = '1000000';
   $('#reelsRPM').value = '0.90';
+  $('#qualifiedPlayRate').value = '100';
+  $('#reelsCreatorShare').value = '45';
   
   syncSliders();
   setURLState();

--- a/facebook-calculator.html
+++ b/facebook-calculator.html
@@ -478,12 +478,20 @@
         <div class="scenario-section" id="reelsSection">
           <h3>🎵 Ads on Reels</h3>
           <div class="input-group">
-            <label for="reelsPlays">Qualified Reels plays (monthly) <span class="info" title="Number of qualified plays on your Reels">ⓘ</span></label>
+            <label for="reelsPlays">Reels plays (monthly) <span class="info" title="Total number of plays on your Reels">ⓘ</span></label>
             <input type="number" id="reelsPlays" min="0" step="1" value="100000">
+          </div>
+          <div class="input-group">
+            <label for="qualifiedPlayRate">Qualified play rate (%) <span class="info" title="Percentage of plays eligible for payouts">ⓘ</span></label>
+            <input type="number" id="qualifiedPlayRate" min="0" max="100" step="1" value="100">
           </div>
           <div class="input-group">
             <label for="reelsRPM">Effective RPM (USD per 1K plays) <span class="info" title="Revenue per 1000 Reels plays">ⓘ</span></label>
             <input type="number" id="reelsRPM" min="0" step="0.01" value="0.90">
+          </div>
+          <div class="input-group">
+            <label for="reelsCreatorShare">Creator revenue share (%) <span class="info" title="Percentage of revenue you receive">ⓘ</span></label>
+            <input type="number" id="reelsCreatorShare" min="0" max="100" step="1" value="45">
           </div>
         </div>
 

--- a/instagram-calculator.html
+++ b/instagram-calculator.html
@@ -423,12 +423,20 @@
         <div class="scenario-section" id="reelsSection">
           <h3>📹 Reels Performance Payouts</h3>
           <div class="input-group">
-            <label for="reelsPlays">Qualified Reels plays (monthly) <span class="info" title="Number of qualified plays on your Reels">ⓘ</span></label>
+            <label for="reelsPlays">Reels plays (monthly) <span class="info" title="Total number of plays on your Reels">ⓘ</span></label>
             <input type="number" id="reelsPlays" min="0" step="1" value="1000000">
+          </div>
+          <div class="input-group">
+            <label for="qualifiedPlayRate">Qualified play rate (%) <span class="info" title="Percentage of plays eligible for payouts">ⓘ</span></label>
+            <input type="number" id="qualifiedPlayRate" min="0" max="100" step="1" value="100">
           </div>
           <div class="input-group">
             <label for="reelsRPM">Effective RPM (USD per 1K plays) <span class="info" title="Revenue per 1000 Reels plays">ⓘ</span></label>
             <input type="number" id="reelsRPM" min="0" step="0.01" value="0.90">
+          </div>
+          <div class="input-group">
+            <label for="reelsCreatorShare">Creator revenue share (%) <span class="info" title="Percentage of revenue you receive">ⓘ</span></label>
+            <input type="number" id="reelsCreatorShare" min="0" max="100" step="1" value="45">
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- support new `qualifiedPlayRate` and `reelsCreatorShare` inputs in Instagram and Facebook calculators
- calculate Reels revenue using qualified plays, RPM and creator share
- expose qualified play rate and creator share fields in both HTML UIs

## Testing
- `node --check assets/instagram-calculator.js`
- `node --check assets/facebook-calculator.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f78776adc832bb056a74739ed5624