### PR TITLE
Add Instagram ID revenue estimator

### DIFF
--- a/assets/instagram-styles.css
+++ b/assets/instagram-styles.css
@@ -470,6 +470,144 @@ h3 {
   }
 }
 
+/* Instagram ID Estimation Styles */
+.channel-input-group {
+  display: flex;
+  gap: 8px;
+  margin-bottom: var(--space);
+}
+.channel-url-input {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 16px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.channel-url-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(228, 64, 95, 0.1);
+}
+
+.time-window-controls {
+  margin: var(--space) 0;
+}
+.radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.radio-group input[type="radio"] {
+  margin-right: 6px;
+  accent-color: var(--accent);
+}
+.radio-group label {
+  font-size: 14px;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.custom-date-range {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+.date-input {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.status-line {
+  font-size: 14px;
+  color: var(--muted);
+  margin: var(--space) 0;
+  min-height: 20px;
+}
+.status-line.success { color: #28a745; }
+.status-line.error { color: #dc3545; }
+.status-line.loading { color: #007bff; }
+.status-line.warning { color: #ffc107; }
+
+.channel-summary {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: var(--space);
+  margin-top: var(--space);
+  background: var(--bg);
+}
+.channel-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: var(--space);
+}
+.channel-info h4 {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+}
+.channel-info h4 a {
+  color: var(--fg);
+  text-decoration: none;
+}
+.channel-info h4 a:hover {
+  color: var(--accent);
+}
+.channel-stats {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.channel-kpis {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space);
+  margin: var(--space) 0;
+}
+.kpi-card {
+  text-align: center;
+  padding: var(--space);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.kpi-label {
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.kpi-value {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+@media (max-width: 480px) {
+  .channel-input-group {
+    flex-direction: column;
+  }
+  .radio-group {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .custom-date-range {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .channel-kpis {
+    grid-template-columns: 1fr;
+  }
+  .channel-header {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
 /* High contrast mode support */
 @media (prefers-contrast: high) {
   :root {

--- a/instagram-calculator.html
+++ b/instagram-calculator.html
@@ -326,6 +326,57 @@
       <p>Estimate earnings in <strong>USD</strong> for <strong>organic, policy-safe</strong> content across Gifts, Subscriptions, and Reels performance payouts.</p>
     </header>
 
+    <!-- Instagram ID Estimator -->
+    <section class="card" id="instaEstimator" style="margin-bottom: var(--space-lg);">
+      <h3>📊 Estimate by Instagram ID</h3>
+      <div class="channel-input-group">
+        <input type="text" id="instaInput" placeholder="Enter an Instagram @handle..." class="channel-url-input">
+        <button class="btn" id="fetchInstaBtn">Fetch</button>
+      </div>
+
+      <div class="time-window-controls">
+        <div class="radio-group">
+          <input type="radio" id="itime30" name="instaTimeWindow" value="30" checked>
+          <label for="itime30">Last 30 days</label>
+          <input type="radio" id="itime90" name="instaTimeWindow" value="90">
+          <label for="itime90">Last 90 days</label>
+          <input type="radio" id="itime365" name="instaTimeWindow" value="365">
+          <label for="itime365">Last 365 days</label>
+          <input type="radio" id="itimeCustom" name="instaTimeWindow" value="custom">
+          <label for="itimeCustom">Custom range</label>
+        </div>
+        <div class="custom-date-range hidden" id="instaCustomRange">
+          <input type="date" id="instaStartDate" class="date-input">
+          <span>to</span>
+          <input type="date" id="instaEndDate" class="date-input">
+        </div>
+      </div>
+
+      <div class="status-line" id="instaStatus"></div>
+
+      <div class="channel-summary hidden" id="instaSummary">
+        <div class="channel-header">
+          <div class="channel-info">
+            <h4 id="instaTitle">@username</h4>
+            <div class="channel-stats">
+              <span id="instaDateRange">Last 30 days</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="channel-kpis">
+          <div class="kpi-card">
+            <div class="kpi-label">Estimated Revenue</div>
+            <div class="kpi-value" id="instaRevenue">$0</div>
+          </div>
+          <div class="kpi-card">
+            <div class="kpi-label">Overall RPM</div>
+            <div class="kpi-value" id="instaRPM">$0</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- Eligibility Checklist -->
     <section class="card" id="eligibilitySection" style="margin-bottom: var(--space-lg);">
       <h3>📋 Eligibility Requirements</h3>


### PR DESCRIPTION
## Summary
- add Instagram handle estimator with selectable time ranges
- generate mock metrics and populate calculator fields
- style estimator UI for Instagram page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f896057c8832bac97b567374e1d03