### PR TITLE
Remove duplicate OG tags in YouTube calculator

### DIFF
--- a/youtube-calculator.html
+++ b/youtube-calculator.html
@@ -13,11 +13,6 @@
   <meta name="robots" content="index, follow" />
   <meta name="color-scheme" content="light" />
 
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="YouTube Monetization Calculator — Estimate Creator Earnings (USD)" />
-  <meta property="og:description" content="Mobile-friendly YouTube Monetization Calculator to estimate earnings for organic, policy-safe content. Supports Long-form, Shorts, and Premium revenue in USD." />
-
   <!-- Additional SEO Meta Tags -->
   <meta name="rating" content="general" />
   <meta name="distribution" content="global" />


### PR DESCRIPTION
## Summary
- remove redundant Open Graph meta tags from the YouTube calculator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f987f95a8832ba9aa497c340b7cf8