### PR TITLE
fix: update canonical and hreflang URLs

### DIFF
--- a/ca/term-life-insurance-premium-calculator/index.html
+++ b/ca/term-life-insurance-premium-calculator/index.html
@@ -18,9 +18,9 @@
   <meta name="revisit-after" content="7 days" />
 
   <!-- Canonical and hreflang -->
-  <link rel="canonical" href="https://your-domain.com/ca/term-life-insurance-premium-calculator/" />
-  <link rel="alternate" hreflang="en-US" href="https://your-domain.com/us/term-life-insurance-premium-calculator/" />
-  <link rel="alternate" hreflang="en-CA" href="https://your-domain.com/ca/term-life-insurance-premium-calculator/" />
+  <link rel="canonical" href="https://financialcalculator.replit.app/ca/term-life-insurance-premium-calculator/" />
+  <link rel="alternate" hreflang="en-US" href="https://financialcalculator.replit.app/us/term-life-insurance-premium-calculator/" />
+  <link rel="alternate" hreflang="en-CA" href="https://financialcalculator.replit.app/ca/term-life-insurance-premium-calculator/" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />

--- a/us/term-life-insurance-premium-calculator/index.html
+++ b/us/term-life-insurance-premium-calculator/index.html
@@ -18,9 +18,9 @@
   <meta name="revisit-after" content="7 days" />
 
   <!-- Canonical and hreflang -->
-  <link rel="canonical" href="https://your-domain.com/us/term-life-insurance-premium-calculator/" />
-  <link rel="alternate" hreflang="en-US" href="https://your-domain.com/us/term-life-insurance-premium-calculator/" />
-  <link rel="alternate" hreflang="en-CA" href="https://your-domain.com/ca/term-life-insurance-premium-calculator/" />
+  <link rel="canonical" href="https://financialcalculator.replit.app/us/term-life-insurance-premium-calculator/" />
+  <link rel="alternate" hreflang="en-US" href="https://financialcalculator.replit.app/us/term-life-insurance-premium-calculator/" />
+  <link rel="alternate" hreflang="en-CA" href="https://financialcalculator.replit.app/ca/term-life-insurance-premium-calculator/" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />


### PR DESCRIPTION
## Summary
- point canonical links for US/CA term life premium calculators to financialcalculator.replit.app
- cross-link US and CA pages via updated `hreflang` references

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b1269a0832bb820bfd6f0373d46