### PR TITLE
Remove mortgage rate ticker from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,6 @@
       <!-- Header + Subtitle -->
       <header class="text-center mb-4">
       <h1 class="h3 mb-2">Free Mortgage Calculator — Canada & USA</h1>
-      <div id="rate-ticker" class="rate-ticker"></div>
       <p class="text-muted mb-0">Calculate monthly payments and total monthly cost of ownership. Includes CMHC (Canada) and PMI/FHA (USA), with purchase or refinance scenarios.</p>
 
 


### PR DESCRIPTION
## Summary
- delete mortgage rate ticker from the homepage header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fab51d2d0832b8ada0a03d658e115