### PR TITLE
fix: correct Facebook overall RPM calculation

### DIFF
--- a/assets/facebook-calculator.js
+++ b/assets/facebook-calculator.js
@@ -117,9 +117,10 @@ const calc = () => {
   
   const total = starsUSD + subscriptionsUSD + reelsUSD + longformUSD + brandedUSD;
 
-  // Overall RPM calculation
+  // Overall RPM should only reflect revenue tied directly to plays or views
+  const viewRevenue = reelsUSD + longformUSD;
   const totalEligible = qualifiedPlays + eligibleViews;
-  const overallRPM = totalEligible > 0 ? (total / totalEligible) * 1000 : 0;
+  const overallRPM = totalEligible > 0 ? (viewRevenue / totalEligible) * 1000 : 0;
 
   return { starsUSD, subscriptionsUSD, reelsUSD, longformUSD, brandedUSD, total, overallRPM, qualifiedPlays, eligibleViews };
 };


### PR DESCRIPTION
## Summary
- avoid inflated RPM by excluding Stars, Subscriptions, and Branded Content from view-based RPM calculation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a011b34014832b9283827324455292