### PR TITLE
Use programmatic eligibility flag

### DIFF
--- a/facebook-calculator.html
+++ b/facebook-calculator.html
@@ -252,24 +252,19 @@
       <p class="small-text">All requirements must be met to use the calculator:</p>
       <div class="eligibility-checklist">
         <div class="checkbox">
-          <input type="checkbox" id="eligibility1">
-          <label for="eligibility1">Country/tool availability ✓</label>
+          <label>Country/tool availability ✓</label>
         </div>
         <div class="checkbox">
-          <input type="checkbox" id="eligibility2">
-          <label for="eligibility2">Partner Monetization Policies & Content Monetization Policies ✓</label>
+          <label>Partner Monetization Policies & Content Monetization Policies ✓</label>
         </div>
         <div class="checkbox">
-          <input type="checkbox" id="eligibility3">
-          <label for="eligibility3">Advertiser-friendly suitability ✓</label>
+          <label>Advertiser-friendly suitability ✓</label>
         </div>
         <div class="checkbox">
-          <input type="checkbox" id="eligibility4">
-          <label for="eligibility4">Originality (no reposting/limited originality) ✓</label>
+          <label>Originality (no reposting/limited originality) ✓</label>
         </div>
         <div class="checkbox">
-          <input type="checkbox" id="eligibility5">
-          <label for="eligibility5">Payout setup & account health ✓</label>
+          <label>Payout setup & account health ✓</label>
         </div>
       </div>
       <div class="eligibility-warning hidden" id="eligibilityWarning">


### PR DESCRIPTION
## Summary
- Remove manual eligibility checkboxes from Facebook calculator UI
- Gate calculations using a new `profileEligible` flag instead of user-checked boxes
- Tie eligibility to Page URL estimation and skip calculations when not eligible

## Testing
- `node --check assets/facebook-calculator.js`
- Manual UI test not run (npm install jsdom failed: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68a0ac5a307c832b8c73490d8de9321d