### PR TITLE
Expose Facebook eligibility breakdown in calculator

### DIFF
--- a/assets/facebook-calculator.js
+++ b/assets/facebook-calculator.js
@@ -309,15 +309,18 @@ const estimateFromPageUrl = async () => {
     const eligibility = pageMeetsMonetization(estimatedData);
     profileEligible = eligibility.eligible;
     checkEligibility();
+    showEligibilityBreakdown(eligibility);
+
+    const summary = `Met: ${eligibility.met.join(', ') || 'none'}; Unmet: ${eligibility.unmet.join(', ') || 'none'}.`;
 
     if (!eligibility.eligible) {
-      showStatus(`Page is not eligible for monetization. Needs: ${eligibility.unmet.join(', ')}.`, 'error');
+      showStatus(`Page is not eligible for monetization. ${summary}`, 'error');
       return;
     }
 
     populateInputsFromEstimate(estimatedData);
 
-    showStatus(`Estimate complete! Revenue calculated for ${getSelectedDateRange().from} to ${getSelectedDateRange().to} based on page analysis.`, 'success');
+    showStatus(`Estimate complete! ${summary} Revenue calculated for ${getSelectedDateRange().from} to ${getSelectedDateRange().to} based on page analysis.`, 'success');
 
     // Scroll to results
     $('#results').scrollIntoView({ behavior: 'smooth' });
@@ -409,8 +412,9 @@ const pageMeetsMonetization = data => {
   const met = [];
   const unmet = [];
   criteria.forEach(c => (c.condition ? met.push(c.label) : unmet.push(c.label)));
+  const eligible = unmet.length === 0;
 
-  return { eligible: unmet.length === 0, met, unmet };
+  return { eligible, met, unmet };
 };
 
 const estimatePageSize = (pageHandle) => {
@@ -552,6 +556,18 @@ const showStatus = (message, type = 'info') => {
   statusText.textContent = message;
   statusLine.className = `status-line ${type}`;
   statusLine.style.display = 'block';
+};
+
+const showEligibilityBreakdown = ({ met, unmet }) => {
+  const panel = $('#eligibilityPanel');
+  const metList = $('#criteriaMet');
+  const unmetList = $('#criteriaUnmet');
+
+  if (!panel || !metList || !unmetList) return;
+
+  metList.innerHTML = met.map(item => `<li>${item}</li>`).join('');
+  unmetList.innerHTML = unmet.map(item => `<li>${item}</li>`).join('');
+  panel.style.display = 'block';
 };
 
 const handleDatePreset = (days) => {

--- a/facebook-calculator.html
+++ b/facebook-calculator.html
@@ -301,7 +301,16 @@
       <div class="status-line" id="statusLine" style="margin-top: 12px; padding: 8px; background: var(--card); border-radius: 4px; font-size: 14px; display: none;">
         <span id="statusText">Ready to estimate...</span>
       </div>
-      
+
+      <div id="eligibilityPanel" style="margin-top: 12px; padding: 8px; background: var(--card); border-radius: 4px; font-size: 14px; display: none;">
+        <div><strong>Met criteria</strong>
+          <ul id="criteriaMet" style="margin: 4px 0 0 16px;"></ul>
+        </div>
+        <div style="margin-top: 8px;"><strong>Unmet criteria</strong>
+          <ul id="criteriaUnmet" style="margin: 4px 0 0 16px;"></ul>
+        </div>
+      </div>
+
       <div class="estimate-disclaimer" style="margin-top: 12px; padding: 12px; background: #fff3cd; border-radius: 8px; border: 1px solid #f39c12;">
         <small style="color: #856404; line-height: 1.4;">
           <strong>Public Estimate Mode:</strong> Approximate earnings based on public metrics and user-provided RPMs. For actual payouts, check your Meta Professional Dashboard → Monetization.


### PR DESCRIPTION
## Summary
- Return detailed eligibility info (met & unmet criteria) from Facebook monetization check
- Display eligibility summary in estimates and populate new criteria panel
- Add eligibility panel to the Facebook calculator UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfcd2c34832ba424a4ff51d3d8a6